### PR TITLE
Set hConfigurationMapFile to NULL to avoid wild closehandle

### DIFF
--- a/rpcFirewall/dllmain.cpp
+++ b/rpcFirewall/dllmain.cpp
@@ -660,6 +660,7 @@ void loadConfigurationFromMappedMemory()
 		{
 			WRITE_DEBUG_MSG_WITH_GETLASTERROR(TEXT("Error: Could not map view of file."));
 			CloseHandle(hConfigurationMapFile);
+			hConfigurationMapFile = NULL;
 		}
 
 		for (int i = 0; i < 5; i++)


### PR DESCRIPTION
In this error branch, hConfigurationMapFile is closed, but later in dllDetatched(), there is this additional call to `CloseHandle`.  Since hConfigurationMapFile was not reset to NULL, this will result in a CloseHandle on the stale value of hConfigurationMapFile (a wild close).

```
	if (hConfigurationMapFile != NULL) CloseHandle(hConfigurationMapFile);
```

https://github.com/zeronetworks/rpcfirewall/blob/cf6a6dc87d9b43dacf1e70f84b0f2c9d595a2411/rpcFirewall/dllmain.cpp#L831